### PR TITLE
chore: adiciona configuração de CI para execução de testes automatizados do backend

### DIFF
--- a/.github/workflows/backend-ci.yml
+++ b/.github/workflows/backend-ci.yml
@@ -1,0 +1,52 @@
+name: CI - Backend Tests
+
+on:
+  ['push', 'pull_request']:
+    branches:
+      - dev
+
+jobs:
+  laravel-tests:
+    runs-on: ubuntu-latest
+
+    services:
+      mysql:
+        image: mysql:8.0
+        env:
+          MYSQL_ROOT_PASSWORD: root
+          MYSQL_DATABASE: testing_db
+        ports:
+          - 3306:3306
+        options: --health-cmd="mysqladmin ping --silent" --health-interval=10s --health-timeout=5s --health-retries=3
+
+    steps:
+    - name: Clonar o projeto
+      uses: actions/checkout@v3
+
+    - name: Configurar PHP
+      uses: shivammathur/setup-php@v2
+      with:
+        php-version: 8.2
+        extensions: mbstring, pdo, pdo_mysql
+        coverage: none
+
+    - name: Instalar dependências do Laravel
+      working-directory: backend
+      run: |
+        composer install --prefer-dist --no-progress --no-suggest
+
+    - name: Preparar arquivo .env
+      working-directory: backend
+      run: |
+        cp .env.example .env
+        php artisan key:generate
+
+    - name: Rodar migrations
+      working-directory: backend
+      run: |
+        php artisan migrate --force
+
+    - name: Rodar testes
+      working-directory: backend
+      run: |
+        php artisan test


### PR DESCRIPTION
## O que foi feito:

- Adicionado arquivo `.github/workflows/ci.yml` para configurar a execução de testes automatizados via GitHub Actions.
- Pipeline configurado para:
  - Rodar em pushs e pull requests na branch `dev`
  - Instalar dependências do Laravel (composer install)
  - Gerar `.env` e chave de aplicação (`php artisan key:generate`)
  - Rodar migrations em ambiente de testes
  - Executar `php artisan test` automaticamente

## Como testar:

- Criar um novo commit na branch `dev` ou abrir um Pull Request para `dev`
- Verificar se o GitHub Actions executa o pipeline chamado **"CI - Backend Tests"**
- Confirmar se os testes passam com sucesso

## Observações:

- Atualmente o CI cobre apenas o backend (`/backend`).
- Configuração para o frontend (`/frontend`) poderá ser adicionada futuramente.
- Branch Protection Rules ainda não foram configuradas.
