### PR TITLE
Finaliza CRUD de Tasks com Testes Automatizados

### DIFF
--- a/backend/app/Http/Controllers/Api/TaskController.php
+++ b/backend/app/Http/Controllers/Api/TaskController.php
@@ -1,0 +1,141 @@
+<?php
+
+namespace App\Http\Controllers\Api;
+
+use App\Http\Controllers\Controller;
+use Illuminate\Http\Request;
+use App\Models\Task;
+use Illuminate\Support\Facades\Validator;
+use App\Http\Controllers\FormErrorController;
+
+class TaskController extends Controller
+{
+    public function index()
+    {
+        $myTasks = auth()->user()->tasks;
+        return response()->json([
+            'status' => 'success',
+            'tasks' => $myTasks,
+        ]);
+    }
+
+    public function store(Request $request)
+    {
+        $validator = Validator::make($request->all(), [
+            'title' => ['required', 'string', 'max:255'],
+            'description' => ['nullable', 'string', 'max:1000'],
+            'is_completed' => ['required', 'in:0,1'],
+        ], [
+            'title.required' => 'O campo título é obrigatório.',
+            'title.string' => 'O campo título deve ser um texto.',
+            'title.max' => 'O título não pode ter mais que :max caracteres.',
+            'description.string' => 'A descrição deve ser um texto.',
+            'description.max' => 'A descrição não pode ter mais que :max caracteres.',
+            'is_completed.required' => 'O campo status é obrigatório.',
+            'is_completed.in' => 'O status deve ser 0 (pendente) ou 1 (concluído).',
+        ]);
+
+        if ($validator->fails()) {
+            return FormErrorController::validation($validator);
+        }
+
+        $user = auth()->user();
+        
+        if (!$user) {
+            return response()->json([
+                'status' => 'error',
+                'message' => 'Usuário não autenticado.',
+            ], 401);
+        }
+
+        $newTask = Task::create([
+            'user_id' => $user->id,
+            'title' => $request->title,
+            'description' => $request->description,
+            'is_completed' => $request->is_completed,
+        ]);
+
+        return response()->json([
+            'status' => 'success',
+            'task' => $newTask,
+        ], 201);
+
+
+    }
+
+    public function update(Request $request, Task $task)
+    {
+
+        $validator = Validator::make($request->all(), [
+            'title' => ['required', 'string', 'max:255'],
+            'description' => ['nullable', 'string', 'max:1000'],
+            'is_completed' => ['required', 'in:0,1'],
+        ], [
+            'title.required' => 'O campo título é obrigatório.',
+            'title.string' => 'O campo título deve ser um texto.',
+            'title.max' => 'O título não pode ter mais que :max caracteres.',
+            'description.string' => 'A descrição deve ser um texto.',
+            'description.max' => 'A descrição não pode ter mais que :max caracteres.',
+            'is_completed.required' => 'O campo status é obrigatório.',
+            'is_completed.in' => 'O status deve ser 0 (pendente) ou 1 (concluído).',
+        ]);
+
+        if ($validator->fails()) {
+            return FormErrorController::validation($validator);
+        }
+
+        $user = auth()->user();
+        
+        if (!$user) {
+            return response()->json([
+                'status' => 'error',
+                'message' => 'Usuário não autenticado.',
+            ], 401);
+        }
+
+        if ($task->user_id !== $user->id) {
+            return response()->json([
+                'status' => 'error',
+                'message' => 'Você não tem permissão para editar esta tarefa.',
+            ], 403);
+        }
+
+        $task->update([
+            'title' => $request->title,
+            'description' => $request->description,
+            'is_completed' => $request->is_completed,
+        ]);
+
+        return response()->json([
+            'status' => 'success',
+            'task' => $task,
+        ]);
+
+    }
+
+    public function destroy(Task $task)
+    {
+        $user = auth()->user();
+        
+        if (!$user) {
+            return response()->json([
+                'status' => 'error',
+                'message' => 'Usuário não autenticado.',
+            ], 401);
+        }
+
+        if ($task->user_id !== $user->id) {
+            return response()->json([
+                'status' => 'error',
+                'message' => 'Você não tem permissão para editar esta tarefa.',
+            ], 403);
+        }   
+
+        $task->delete();
+
+        return response()->json([
+            'status' => 'success',
+            'message' => 'Tarefa excluída com sucesso.',
+        ], 204);
+    }
+}

--- a/backend/app/Models/Task.php
+++ b/backend/app/Models/Task.php
@@ -1,0 +1,38 @@
+<?php
+
+namespace App\Models;
+
+use Illuminate\Database\Eloquent\Model;
+use Illuminate\Database\Eloquent\Factories\HasFactory;
+
+class Task extends Model
+{
+    use HasFactory;
+    public $incrementing = false;
+    protected $keyType = 'string'; 
+
+    public static function boot()
+    {
+        parent::boot();
+
+        static::creating(function ($model) {
+            if (empty($model->{$model->getKeyName()})) {
+                $model->{$model->getKeyName()} = (string) \Illuminate\Support\Str::uuid();
+            }
+        });
+    }
+    protected $fillable = [
+        'title',
+        'description',
+        'is_completed',
+        'user_id',
+    ];
+    protected $casts = [
+        'created_at' => 'datetime',
+        'updated_at' => 'datetime',
+    ];
+    public function user()
+    {
+        return $this->belongsTo(User::class);
+    }
+}

--- a/backend/app/Models/User.php
+++ b/backend/app/Models/User.php
@@ -11,6 +11,19 @@ use Illuminate\Notifications\Notifiable;
 class User extends Authenticatable
 {
     use HasApiTokens, HasFactory, Notifiable;
+    public $incrementing = false;
+    protected $keyType = 'string'; 
+
+    protected static function boot()
+    {
+        parent::boot();
+
+        static::creating(function ($model) {
+            if (empty($model->{$model->getKeyName()})) {
+                $model->{$model->getKeyName()} = (string) \Illuminate\Support\Str::uuid();
+            }
+        });
+    }
 
     protected $fillable = [
         'name',
@@ -29,5 +42,10 @@ class User extends Authenticatable
             'email_verified_at' => 'datetime',
             'password' => 'hashed',
         ];
+    }
+
+    public function tasks()
+    {
+        return $this->hasMany(Task::class);
     }
 }

--- a/backend/database/factories/TaskFactory.php
+++ b/backend/database/factories/TaskFactory.php
@@ -1,0 +1,22 @@
+<?php
+
+namespace Database\Factories;
+
+use App\Models\Task;
+use App\Models\User;
+use Illuminate\Database\Eloquent\Factories\Factory;
+
+class TaskFactory extends Factory
+{
+    protected $model = Task::class;
+
+    public function definition(): array
+    {
+        return [
+            'title' => $this->faker->sentence(4),
+            'description' => $this->faker->paragraph(2),
+            'is_completed' => $this->faker->boolean,
+            'user_id' => User::factory(),          
+        ];
+    }
+}

--- a/backend/database/factories/UserFactory.php
+++ b/backend/database/factories/UserFactory.php
@@ -4,41 +4,19 @@ namespace Database\Factories;
 
 use Illuminate\Database\Eloquent\Factories\Factory;
 use Illuminate\Support\Facades\Hash;
-use Illuminate\Support\Str;
+use App\Models\User;
 
-/**
- * @extends \Illuminate\Database\Eloquent\Factories\Factory<\App\Models\User>
- */
 class UserFactory extends Factory
 {
-    /**
-     * The current password being used by the factory.
-     */
-    protected static ?string $password;
+    protected $model = User::class;
 
-    /**
-     * Define the model's default state.
-     *
-     * @return array<string, mixed>
-     */
     public function definition(): array
     {
         return [
             'name' => fake()->name(),
             'email' => fake()->unique()->safeEmail(),
-            'email_verified_at' => now(),
-            'password' => static::$password ??= Hash::make('password'),
-            'remember_token' => Str::random(10),
+            'password' => Hash::make('my_secure_password'),
         ];
     }
 
-    /**
-     * Indicate that the model's email address should be unverified.
-     */
-    public function unverified(): static
-    {
-        return $this->state(fn (array $attributes) => [
-            'email_verified_at' => null,
-        ]);
-    }
 }

--- a/backend/database/migrations/2025_04_27_111724_create_personal_access_tokens_table.php
+++ b/backend/database/migrations/2025_04_27_111724_create_personal_access_tokens_table.php
@@ -13,7 +13,7 @@ return new class extends Migration
     {
         Schema::create('personal_access_tokens', function (Blueprint $table) {
             $table->id();
-            $table->morphs('tokenable');
+            $table->uuidMorphs('tokenable');
             $table->string('name');
             $table->string('token', 64)->unique();
             $table->text('abilities')->nullable();

--- a/backend/database/migrations/2025_04_27_122807_create_tasks_table.php
+++ b/backend/database/migrations/2025_04_27_122807_create_tasks_table.php
@@ -11,13 +11,13 @@ return new class extends Migration
      */
     public function up(): void
     {
-        Schema::create('users', function (Blueprint $table) {
+        Schema::create('tasks', function (Blueprint $table) {
             $table->uuid('id')->primary();
-            $table->string('name');
-            $table->string('email')->unique();
-            $table->timestamp('email_verified_at')->nullable();
-            $table->string('password');
-            $table->rememberToken();
+            $table->uuid('user_id');
+            $table->foreign('user_id')->references('id')->on('users')->onDelete('cascade');
+            $table->string('title');
+            $table->text('description')->nullable();
+            $table->boolean('is_completed')->default(false);
             $table->timestamps();
         });
     }
@@ -27,6 +27,6 @@ return new class extends Migration
      */
     public function down(): void
     {
-        Schema::dropIfExists('users');
+        Schema::dropIfExists('tasks');
     }
 };

--- a/backend/routes/api.php
+++ b/backend/routes/api.php
@@ -2,11 +2,17 @@
 
 use Illuminate\Support\Facades\Route;
 use App\Http\Controllers\Api\AuthController;
+use App\Http\Controllers\Api\TaskController;
 
 Route::post('/login', [AuthController::class, 'login'])->name('login');
 Route::post('/register', [AuthController::class, 'register'])->name('register');
 
 Route::middleware(['auth:sanctum'])->group(function () {
+    Route::get('/tasks', [TaskController::class, 'index'])->name('tasks.index');
+    Route::post('/tasks', [TaskController::class, 'store'])->name('tasks.store');
+    Route::put('/tasks/{task}', [TaskController::class, 'update'])->name('tasks.update');
+    Route::delete('/tasks/{task}', [TaskController::class, 'destroy'])->name('tasks.destroy');
+
     Route::post('/logout', [AuthController::class, 'logout'])->name('logout');
 });
 

--- a/backend/tests/Feature/TaskTest.php
+++ b/backend/tests/Feature/TaskTest.php
@@ -1,0 +1,144 @@
+<?php
+
+namespace Tests\Feature;
+
+use App\Models\Task;
+use App\Models\User;
+use Illuminate\Foundation\Testing\RefreshDatabase;
+use Tests\TestCase;
+use Laravel\Sanctum\Sanctum;
+
+
+class TaskTest extends TestCase
+{
+    use RefreshDatabase;
+
+    public function test_user_can_list_tasks()
+    {
+        $user = User::factory()->create();
+        Sanctum::actingAs($user);
+
+        Task::factory()->count(3)->create([
+            'user_id' => $user->id,
+        ]);
+
+        $response = $this->getJson('/api/tasks');
+
+        $response->assertStatus(200)
+                 ->assertJsonStructure([
+                     'status',
+                     'tasks' => [
+                         '*' => [
+                             'id',
+                             'user_id',
+                             'title',
+                             'description',
+                             'is_completed',
+                             'created_at',
+                             'updated_at',
+                         ],
+                     ],
+                 ]);
+    }
+
+    public function test_user_can_create_task()
+    {
+        $user = User::factory()->create();
+        Sanctum::actingAs($user);
+
+        $taskData = [
+            'title' => fake()->sentence(4),
+            'description' => fake()->paragraph(2),
+            'is_completed' => 0,
+        ];
+
+        $response = $this->postJson('/api/tasks', $taskData);
+
+        $response->assertStatus(201)
+                 ->assertJsonFragment([
+                     'title' => $taskData['title'],
+                     'description' => $taskData['description'],
+                     'is_completed' => $taskData['is_completed'],
+                 ])
+                 ->assertJsonStructure([
+                     'status',
+                     'task' => [
+                         'id',
+                         'user_id',
+                         'title',
+                         'description',
+                         'is_completed',
+                         'created_at',
+                         'updated_at',
+                     ],
+                 ]);
+
+        $this->assertDatabaseHas('tasks', [
+            'title' => $taskData['title'],
+            'description' => $taskData['description'],
+            'is_completed' => $taskData['is_completed'],
+        ]);
+    }
+
+    public function test_user_can_update_task()
+    {
+        $user = User::factory()->create();
+        Sanctum::actingAs($user);
+
+        $task = Task::factory()->create([
+            'user_id' => $user->id,
+        ]);
+
+        $updateData = [
+            'title' => fake()->sentence(3),
+            'description' => fake()->paragraph(1),
+            'is_completed' => true,
+        ];
+
+        $response = $this->putJson("/api/tasks/{$task->id}", $updateData);
+
+        $response->assertStatus(200)
+                 ->assertJsonFragment([
+                     'title' => $updateData['title'],
+                     'description' => $updateData['description'],
+                     'is_completed' => $updateData['is_completed'],
+                 ])
+                 ->assertJsonStructure([
+                     'status',
+                     'task' => [
+                         'id',
+                         'user_id',
+                         'title',
+                         'description',
+                         'is_completed',
+                         'created_at',
+                         'updated_at',
+                     ],
+                 ]);
+
+        $this->assertDatabaseHas('tasks', [
+            'id' => $task->id,
+            'title' => $updateData['title'],
+            'description' => $updateData['description'],
+            'is_completed' => $updateData['is_completed'],
+        ]);
+    }
+
+    public function test_user_can_delete_task()
+    {
+        $user = User::factory()->create();
+        Sanctum::actingAs($user);
+
+        $task = Task::factory()->create([
+            'user_id' => $user->id,
+        ]);
+
+        $response = $this->deleteJson("/api/tasks/{$task->id}");
+
+        $response->assertStatus(204);
+
+        $this->assertDatabaseMissing('tasks', [
+            'id' => $task->id,
+        ]);
+    }
+}


### PR DESCRIPTION
## Descrição

Este PR finaliza a implementação do CRUD de tarefas na API, incluindo:

- Endpoint para criar tarefas (POST /api/tasks)
- Endpoint para listar tarefas (GET /api/tasks)
- Endpoint para atualizar tarefas (PUT /api/tasks/{id})
- Endpoint para deletar tarefas (DELETE /api/tasks/{id})
- Testes automatizados de Feature para todas as operações
- Utilização de Factories com Faker para geração de dados de teste
